### PR TITLE
Feature: React Native와 Webview 인증 토큰 브릿지 추가

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "Runova_FE",
     "slug": "Runova_FE",
+    "owner": "monicx",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -11,7 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
-
+.idea
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/apps/web/src/hooks/useLogNativeToken.ts
+++ b/apps/web/src/hooks/useLogNativeToken.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { useNativeBridgeStore } from '@/stores/nativeBridgeStore';
+import { postToNative } from '@/lib/nativeBridge';
+
+export function useLogNativeToken(pageLabel: string) {
+  const token = useNativeBridgeStore((s) => s.token);
+  const init = useNativeBridgeStore((s) => s.init);
+
+  // 최초 진입 시, 아직 토큰이 없다면 RN에 존재 확인용 신호(PING) 한번 보내기(선택)
+  useEffect(() => {
+    if (!token) {
+      postToNative({ type: 'PING' }); // 선택: 로그 연결 확인용
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // init 수신되면 로그
+  useEffect(() => {
+    if (init) {
+      console.log(`[${pageLabel}] NATIVE_INIT`, init);
+    }
+  }, [init, pageLabel]);
+
+  // token 수신/갱신되면 로그
+  useEffect(() => {
+    if (token) {
+      console.log(`[${pageLabel}] ACCESS_TOKEN`, token);
+    }
+  }, [token, pageLabel]);
+
+  return { token, init };
+}

--- a/apps/web/src/lib/nativeBridge.ts
+++ b/apps/web/src/lib/nativeBridge.ts
@@ -1,0 +1,34 @@
+import { useNativeBridgeStore } from '@/stores/nativeBridgeStore';
+import type { RNToWebMessage, WebToRNMessage } from '@/types/nativeBridge.type';
+
+// JSON 또는 객체 수신을 안전히 파싱
+function parseIncoming(data: unknown): RNToWebMessage | null {
+  try {
+    if (typeof data === 'string') return JSON.parse(data) as RNToWebMessage;
+    if (typeof data === 'object' && data) return data as RNToWebMessage;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function onMessage(e: MessageEvent) {
+  const msg = parseIncoming(e.data);
+  if (!msg || typeof msg !== 'object' || !('type' in msg)) return;
+  useNativeBridgeStore.getState().setFromNative(msg);
+}
+
+// iOS/Android 호환 위해 둘 다 리스닝
+window.addEventListener('message', onMessage as EventListener);
+document.addEventListener('message', onMessage as unknown as EventListener);
+
+/** Web → RN 송신 */
+export function postToNative(message: WebToRNMessage) {
+  const str = JSON.stringify(message);
+  window.ReactNativeWebView?.postMessage(str);
+}
+
+/** 간단 테스트용 */
+export const sendPing = () => postToNative({ type: 'PING' });
+export const requestRefreshToken = () =>
+  postToNative({ type: 'REFRESH_TOKEN' });

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from '@emotion/react';
 import { theme } from '@/styles/theme';
 import GlobalStyle from '@/styles/global';
 import App from './App';
+import './lib/nativeBridge';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/apps/web/src/pages/Community/CommunityList/index.tsx
+++ b/apps/web/src/pages/Community/CommunityList/index.tsx
@@ -5,11 +5,15 @@ import SectionCarousel from './_components/SectionCarousel';
 import PostCard from '../_components/Postcard';
 import CommunityAppLayout from '../_components/CommunityAppLayout';
 import Fab from '../_components/Fab';
+import { useLogNativeToken } from '@/hooks/useLogNativeToken';
 import type { Post } from '@/types/community';
 
 export default function CommunityList() {
   const navigate = useNavigate();
 
+  const { token, init } = useLogNativeToken('Community');
+
+  console.log(token, init);
   const mkPost = (
     seed: number,
     category: Post['category'],

--- a/apps/web/src/pages/Community/CommunityList/index.tsx
+++ b/apps/web/src/pages/Community/CommunityList/index.tsx
@@ -5,15 +5,11 @@ import SectionCarousel from './_components/SectionCarousel';
 import PostCard from '../_components/Postcard';
 import CommunityAppLayout from '../_components/CommunityAppLayout';
 import Fab from '../_components/Fab';
-import { useLogNativeToken } from '@/hooks/useLogNativeToken';
 import type { Post } from '@/types/community';
 
 export default function CommunityList() {
   const navigate = useNavigate();
 
-  const { token, init } = useLogNativeToken('Community');
-
-  console.log(token, init);
   const mkPost = (
     seed: number,
     category: Post['category'],

--- a/apps/web/src/stores/nativeBridgeStore.ts
+++ b/apps/web/src/stores/nativeBridgeStore.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+import type { NativeInitPayload, RNToWebMessage } from '@/types/nativeBridge.type';
+
+type BridgeState = {
+  init: NativeInitPayload | null; // RN이 준 초기 페이로드
+  token: string | null; // 최신 액세스 토큰
+  lastMessage: RNToWebMessage | null;
+  setFromNative: (msg: RNToWebMessage) => void;
+  clear: () => void;
+};
+
+export const useNativeBridgeStore = create<BridgeState>((set) => ({
+  init: null,
+  token: null,
+  lastMessage: null,
+
+  setFromNative: (msg) =>
+    set((prev) => {
+      let init = prev.init;
+      let token = prev.token;
+
+      switch (msg.type) {
+        case 'NATIVE_INIT':
+          init = msg.payload;
+          token = msg.payload.accessToken;
+          break;
+        case 'NATIVE_TOKEN':
+          token = msg.payload;
+          break;
+        case 'NATIVE_TOKEN_ERROR':
+          token = null;
+          break;
+        default:
+          // 다른 타입들은 lastMessage로만 보관
+          break;
+      }
+      return { init, token, lastMessage: msg };
+    }),
+
+  clear: () => ({ init: null, token: null, lastMessage: null }),
+}));

--- a/apps/web/src/types/nativeBridge.type.ts
+++ b/apps/web/src/types/nativeBridge.type.ts
@@ -1,0 +1,24 @@
+export type NormalizedUser = {
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  avatarUrl?: string | null;
+} | null;
+
+export type NativeInitPayload = {
+  user: NormalizedUser;
+  accessToken: string | null;
+  app: { platform: 'native'; version?: string };
+};
+
+export type RNToWebMessage =
+  | { type: 'NATIVE_INIT'; payload: NativeInitPayload }
+  | { type: 'NATIVE_TOKEN'; payload: string }
+  | { type: 'NATIVE_TOKEN_ERROR' }
+  | { type: 'PONG' };
+
+export type WebToRNMessage =
+  | { type: 'PING' }
+  | { type: 'REFRESH_TOKEN' }
+  | { type: 'LOG'; payload?: unknown }
+  | { type: string; payload?: unknown };

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+declare global {
+  interface Window {
+    ReactNativeWebView?: {
+      postMessage: (data: string) => void;
+    };
+  }
+}
+
+export {};

--- a/eas.json
+++ b/eas.json
@@ -10,7 +10,15 @@
     "preview": {
       "distribution": "internal"
     },
-    "production": {}
+    "production": {},
+    "development-simulator": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      },
+      "environment": "development"
+    }
   },
   "submit": {
     "production": {}

--- a/src/components/WebScreen.tsx
+++ b/src/components/WebScreen.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import WebView from 'react-native-webview';
 
+import { useWebViewMessenger } from '@/hooks/useWebViewMessenger';
+
 export default function WebScreen({
   origin,
   path,
@@ -11,9 +13,21 @@ export default function WebScreen({
 }) {
   const insets = useSafeAreaInsets();
 
+  // 메시징 훅 사용
+  const { webRef, onLoadEnd, onMessage } = useWebViewMessenger();
+
   return (
     <Container safeAreaTop={insets.top}>
-      <StyledWebView source={{ uri: `${origin}${path}` }} />
+      <StyledWebView
+        ref={webRef}
+        source={{ uri: `${origin}${path}` }}
+        onLoadEnd={onLoadEnd} // RN → Web : 로그인정보/토큰 보내기
+        onMessage={onMessage} // Web → RN : 메시지 받기
+        javaScriptEnabled
+        domStorageEnabled
+        originWhitelist={['*']}
+        sharedCookiesEnabled
+      />
     </Container>
   );
 }

--- a/src/hooks/useWebViewMessenger.ts
+++ b/src/hooks/useWebViewMessenger.ts
@@ -1,0 +1,140 @@
+import { useCallback, useMemo, useRef } from 'react';
+import WebView, { WebViewMessageEvent } from 'react-native-webview';
+
+import api from '@/lib/api';
+import useAuthStore from '@/store/auth';
+import type { User } from '@/types/user.types';
+
+type NormalizedUser = {
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  avatarUrl?: string | null;
+} | null;
+
+type NativeInitPayload = {
+  user: NormalizedUser;
+  accessToken: string | null;
+  app: { platform: 'native'; version?: string };
+};
+
+type NativeMessage =
+  | { type: 'NATIVE_INIT'; payload: NativeInitPayload }
+  | { type: 'NATIVE_TOKEN'; payload: string }
+  | { type: 'NATIVE_TOKEN_ERROR' }
+  | { type: 'PONG' }
+  | { type: string; payload?: unknown }; // 확장성 위해 기본 구조 유지
+
+type WebToNativeMessage =
+  | { type: 'PING' }
+  | { type: 'REFRESH_TOKEN' }
+  | { type: 'LOG'; payload?: unknown }
+  | { type: string; payload?: unknown };
+
+export function useWebViewMessenger() {
+  const webRef = useRef<WebView>(null);
+
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const user = useAuthStore((s) => s.user);
+  const setAuth = useAuthStore((s) => s.setAuth);
+  const clearAuth = useAuthStore((s) => s.clearAuth);
+
+  const normalizeUser = (u: User | null): NormalizedUser => {
+    if (!u) return null;
+
+    const rawId: number | string | undefined =
+      (u as { id?: number | string }).id ??
+      (u as { userId?: number | string }).userId;
+
+    return {
+      id: rawId !== undefined ? String(rawId) : '',
+      name:
+        (u as { name?: string }).name ??
+        (u as { displayName?: string }).displayName ??
+        null,
+      email: (u as { email?: string }).email ?? null,
+      avatarUrl:
+        (u as { avatarUrl?: string }).avatarUrl ??
+        (u as { photoUrl?: string }).photoUrl ??
+        null,
+    };
+  };
+
+  const initPayload: NativeInitPayload = useMemo(() => {
+    return {
+      user: normalizeUser(user),
+      accessToken: accessToken ?? null,
+      app: { platform: 'native' },
+    };
+  }, [accessToken, user]);
+
+  const postJson = useCallback((data: NativeMessage) => {
+    console.log('[RN → Web] 보내는 메시지:', data);
+    webRef.current?.postMessage(JSON.stringify(data));
+  }, []);
+
+  const onLoadEnd = useCallback(() => {
+    postJson({ type: 'NATIVE_INIT', payload: initPayload });
+  }, [postJson, initPayload]);
+
+  const onMessage = useCallback(
+    async (e: WebViewMessageEvent) => {
+      console.log('[Web → RN] 원본 데이터:', e.nativeEvent.data);
+
+      let msg: WebToNativeMessage;
+      try {
+        msg = JSON.parse(e.nativeEvent.data) as WebToNativeMessage;
+      } catch {
+        msg = { type: 'LOG', payload: e.nativeEvent.data };
+      }
+
+      switch (msg.type) {
+        case 'PING': {
+          postJson({ type: 'PONG' });
+          break;
+        }
+        case 'REFRESH_TOKEN': {
+          try {
+            const { data } = await api.post<{ accessToken: string }>(
+              '/auth/refresh',
+            );
+            const newToken = data.accessToken;
+
+            if (!newToken) throw new Error('No accessToken in refresh result');
+
+            if (user) {
+              setAuth(newToken, user);
+            } else {
+              clearAuth();
+            }
+
+            postJson({ type: 'NATIVE_TOKEN', payload: newToken });
+          } catch {
+            postJson({ type: 'NATIVE_TOKEN_ERROR' });
+            clearAuth();
+          }
+          break;
+        }
+        case 'LOG': {
+          console.log('[Web LOG]', msg.payload);
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    },
+    [postJson, setAuth, clearAuth, user],
+  );
+
+  const sendToWeb = useCallback(
+    (type: string, payload?: unknown) => {
+      postJson({ type, payload });
+    },
+    [postJson],
+  );
+
+  return { webRef, onLoadEnd, onMessage, sendToWeb };
+}
+
+export type UseWebViewMessengerReturn = ReturnType<typeof useWebViewMessenger>;


### PR DESCRIPTION
## 작업 내용

- react-native-webview의 postmessage 메서드를 기반으로 인증 정보(accessToken)를 넘기는 브릿지를 추가하였습니다.
- web에서 해당 정보들을 받아 처리하는 훅과 zustand store를 추가했습니다.

