### PR TITLE
Feature: 맵 드로잉 기능 api 연동 및 화면 플로우 개선

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,5 +1,5 @@
 import React, { RefObject } from 'react';
-import { StyleSheet } from 'react-native';
+import styled from '@emotion/native';
 import Mapbox from '@rnmapbox/maps';
 import type { Position } from 'geojson';
 import { INITIAL_ZOOM_LEVEL } from '@/constants/location';
@@ -22,11 +22,7 @@ export default function Map({
   showUserLocation = true,
 }: MapProps) {
   return (
-    <Mapbox.MapView
-      ref={mapRef}
-      style={styles.map}
-      styleURL={Mapbox.StyleURL.Street}
-    >
+    <StyledMapView ref={mapRef} styleURL={Mapbox.StyleURL.Street}>
       <Mapbox.Camera
         ref={cameraRef}
         defaultSettings={{
@@ -38,12 +34,10 @@ export default function Map({
         <Mapbox.UserLocation onUpdate={onUserLocationUpdate} />
       )}
       {children}
-    </Mapbox.MapView>
+    </StyledMapView>
   );
 }
 
-const styles = StyleSheet.create({
-  map: {
-    flex: 1,
-  },
-});
+const StyledMapView = styled(Mapbox.MapView)`
+  flex: 1;
+`;

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -6,6 +6,8 @@ import {
 } from '@/lib/filesApi';
 import type { FileUploadType } from '@/types/files.types';
 
+const MAX_IMAGES_SIZE_BYTES = 10 * 1024 * 1024;
+
 export function useImageUpload() {
   const uploadImage = async (
     imageUri: string,
@@ -18,7 +20,7 @@ export function useImageUpload() {
 
     const fileSize = fileInfo.size || 0;
 
-    if (fileSize > 10485760) {
+    if (fileSize > MAX_IMAGES_SIZE_BYTES) {
       throw new Error('이미지 파일이 너무 큽니다. (최대 10MB)');
     }
 

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -1,0 +1,46 @@
+import * as FileSystem from 'expo-file-system';
+import {
+  requestPresignedUrl,
+  uploadImageToS3,
+  generatePublicImageUrl,
+} from '@/lib/filesApi';
+import type { FileUploadType } from '@/types/files.types';
+
+export function useImageUpload() {
+  const uploadImage = async (
+    imageUri: string,
+    accessToken: string,
+  ): Promise<string> => {
+    const fileInfo = await FileSystem.getInfoAsync(imageUri);
+    if (!fileInfo.exists) {
+      throw new Error('이미지 파일을 찾을 수 없습니다.');
+    }
+
+    const fileSize = fileInfo.size || 0;
+
+    if (fileSize > 10485760) {
+      throw new Error('이미지 파일이 너무 큽니다. (최대 10MB)');
+    }
+
+    const uploadType: FileUploadType = 'avatar';
+    const presignData = await requestPresignedUrl(
+      {
+        type: uploadType,
+        contentType: 'image/png',
+        size: fileSize,
+      },
+      accessToken,
+    );
+
+    await uploadImageToS3(presignData.url, imageUri, fileSize);
+
+    const publicImageUrl = generatePublicImageUrl(
+      presignData.bucket,
+      presignData.key,
+    );
+
+    return publicImageUrl;
+  };
+
+  return { uploadImage };
+}

--- a/src/hooks/useLocationManager.ts
+++ b/src/hooks/useLocationManager.ts
@@ -1,0 +1,42 @@
+import { useRef, useEffect } from 'react';
+import type { Position } from 'geojson';
+import type Mapbox from '@rnmapbox/maps';
+import { useInitialLocation } from '@/hooks/useInitialLocation';
+import { FLY_TO_USER_LOCATION_DURATION } from '@/constants/draw';
+
+export function useLocationManager() {
+  const { location: initialLocation, loading: locationLoading } =
+    useInitialLocation();
+  const currentUserLocation = useRef<Position | null>(null);
+
+  useEffect(() => {
+    if (initialLocation) {
+      currentUserLocation.current = initialLocation;
+    }
+  }, [initialLocation]);
+
+  const flyToCurrentUserLocation = (
+    cameraRef: React.RefObject<Mapbox.Camera | null>,
+  ) => {
+    if (currentUserLocation.current) {
+      cameraRef.current?.flyTo(
+        currentUserLocation.current,
+        FLY_TO_USER_LOCATION_DURATION,
+      );
+    }
+  };
+
+  const handleUserLocationUpdate = (location: Mapbox.Location) => {
+    currentUserLocation.current = [
+      location.coords.longitude,
+      location.coords.latitude,
+    ];
+  };
+
+  return {
+    initialLocation,
+    locationLoading,
+    flyToCurrentUserLocation,
+    handleUserLocationUpdate,
+  };
+}

--- a/src/hooks/useMapCapture.ts
+++ b/src/hooks/useMapCapture.ts
@@ -1,7 +1,20 @@
 import type { RefObject } from 'react';
 import type Mapbox from '@rnmapbox/maps';
+import { useImageUpload } from '@/hooks/useImageUpload';
+
+export type ImageProcessResult = {
+  success: boolean;
+  imageURL?: string;
+  error?: string;
+  captureSuccess?: boolean;
+  uploadSuccess?: boolean;
+  captureError?: string;
+  uploadError?: string;
+};
 
 export function useMapCapture(mapRef: RefObject<Mapbox.MapView | null>) {
+  const { uploadImage } = useImageUpload();
+
   const captureMap = async (): Promise<string> => {
     if (!mapRef.current) {
       throw new Error('맵이 준비되지 않았습니다.');
@@ -15,5 +28,36 @@ export function useMapCapture(mapRef: RefObject<Mapbox.MapView | null>) {
     return uri;
   };
 
-  return { captureMap };
+  const processImage = async (
+    accessToken: string,
+  ): Promise<ImageProcessResult> => {
+    try {
+      const capturedImageUri = await captureMap();
+      const uploadedImageUrl = await uploadImage(capturedImageUri, accessToken);
+
+      return {
+        success: true,
+        imageURL: uploadedImageUrl,
+        captureSuccess: true,
+        uploadSuccess: true,
+      };
+    } catch (error: any) {
+      const errorMessage =
+        error.message || '이미지 처리 중 오류가 발생했습니다.';
+      const isCaptureError =
+        errorMessage.includes('맵') || errorMessage.includes('캡처');
+
+      return {
+        success: false,
+        imageURL: '',
+        error: errorMessage,
+        captureSuccess: !isCaptureError,
+        uploadSuccess: isCaptureError,
+        captureError: isCaptureError ? errorMessage : undefined,
+        uploadError: !isCaptureError ? errorMessage : undefined,
+      };
+    }
+  };
+
+  return { captureMap, processImage };
 }

--- a/src/hooks/useMapCapture.ts
+++ b/src/hooks/useMapCapture.ts
@@ -1,65 +1,18 @@
 import type { RefObject } from 'react';
-import * as MediaLibrary from 'expo-media-library';
 import type Mapbox from '@rnmapbox/maps';
-import Toast from 'react-native-toast-message';
 
 export function useMapCapture(mapRef: RefObject<Mapbox.MapView | null>) {
-  const captureMap = async () => {
+  const captureMap = async (): Promise<string> => {
     if (!mapRef.current) {
-      Toast.show({
-        type: 'error',
-        text1: '캡처에 실패했습니다.',
-        text2: '맵이 준비되지 않았습니다.',
-      });
-      return;
+      throw new Error('맵이 준비되지 않았습니다.');
     }
 
-    try {
-      const uri = await mapRef.current.takeSnap(true);
-      if (uri) {
-        await saveImage(uri);
-      }
-    } catch (error) {
-      console.error('Failed to capture map', error);
-      Toast.show({
-        type: 'error',
-        text1: '캡처에 실패했습니다.',
-        text2: '오류가 발생했습니다.',
-      });
-    }
-  };
-
-  const saveImage = async (uri: string) => {
-    const { status } = await MediaLibrary.requestPermissionsAsync();
-    if (status !== 'granted') {
-      Toast.show({
-        type: 'error',
-        text1: '저장 권한이 필요합니다.',
-        text2: '설정에서 권한을 허용해주세요.',
-      });
-      return;
+    const uri = await mapRef.current.takeSnap(true);
+    if (!uri) {
+      throw new Error('맵 캡처에 실패했습니다.');
     }
 
-    try {
-      const asset = await MediaLibrary.createAssetAsync(uri);
-      let album = await MediaLibrary.getAlbumAsync('Runova');
-      if (album === null) {
-        album = await MediaLibrary.createAlbumAsync('Runova', asset, false);
-      } else {
-        await MediaLibrary.addAssetsToAlbumAsync([asset], album, false);
-      }
-      Toast.show({
-        type: 'success',
-        text1: '성공적으로 캡처했습니다.',
-        text2: '갤러리에 이미지를 저장했습니다.',
-      });
-    } catch (error) {
-      console.error('Failed to save image', error);
-      Toast.show({
-        type: 'error',
-        text1: '이미지 저장에 실패했습니다.',
-      });
-    }
+    return uri;
   };
 
   return { captureMap };

--- a/src/hooks/useMapCapture.ts
+++ b/src/hooks/useMapCapture.ts
@@ -1,6 +1,5 @@
 import type { RefObject } from 'react';
 import type Mapbox from '@rnmapbox/maps';
-import { useImageUpload } from '@/hooks/useImageUpload';
 
 export type ImageProcessResult = {
   success: boolean;
@@ -13,8 +12,6 @@ export type ImageProcessResult = {
 };
 
 export function useMapCapture(mapRef: RefObject<Mapbox.MapView | null>) {
-  const { uploadImage } = useImageUpload();
-
   const captureMap = async (): Promise<string> => {
     if (!mapRef.current) {
       throw new Error('맵이 준비되지 않았습니다.');
@@ -33,11 +30,11 @@ export function useMapCapture(mapRef: RefObject<Mapbox.MapView | null>) {
   ): Promise<ImageProcessResult> => {
     try {
       const capturedImageUri = await captureMap();
-      const uploadedImageUrl = await uploadImage(capturedImageUri, accessToken);
 
+      // S3 업로드 없이 캡처한 이미지 URI를 바로 사용
       return {
         success: true,
-        imageURL: uploadedImageUrl,
+        imageURL: capturedImageUri,
         captureSuccess: true,
         uploadSuccess: true,
       };

--- a/src/hooks/useMapCapture.ts
+++ b/src/hooks/useMapCapture.ts
@@ -1,20 +1,11 @@
 import type { RefObject } from 'react';
 import type Mapbox from '@rnmapbox/maps';
 import useDrawStore from '@/store/draw';
+import { ImageProcessResult } from '@/types/image.types';
 
 const BOUNDS_PADDING = 0.6;
 const ANIMATION_DURATION = 1000;
 const TIMEOUT = 1200;
-
-export type ImageProcessResult = {
-  success: boolean;
-  imageURL?: string;
-  error?: string;
-  captureSuccess?: boolean;
-  uploadSuccess?: boolean;
-  captureError?: string;
-  uploadError?: string;
-};
 
 export function useMapCapture(
   mapRef: RefObject<Mapbox.MapView | null>,

--- a/src/hooks/useRouteValidation.ts
+++ b/src/hooks/useRouteValidation.ts
@@ -1,0 +1,58 @@
+import { mergeMatchedRoutes, convertToApiFormat } from '@/utils/draw';
+import useDrawStore from '@/store/draw';
+
+export type ValidationResult = {
+  isValid: boolean;
+  error?: string;
+  data?: {
+    title: string;
+    path: any[];
+  };
+};
+
+export function useRouteValidation() {
+  const { matchedRoutes } = useDrawStore();
+
+  const validateRoute = (accessToken: string): ValidationResult => {
+    if (!accessToken) {
+      return { isValid: false, error: '로그인이 필요합니다.' };
+    }
+    if (matchedRoutes.length === 0) {
+      return {
+        isValid: false,
+        error: '저장할 경로가 없습니다. 먼저 경로를 그려주세요.',
+      };
+    }
+    const title = `GPS 아트 경로 ${new Date().toLocaleDateString()}`;
+    const mergedCoordinates = mergeMatchedRoutes(matchedRoutes);
+    if (mergedCoordinates.length < 2) {
+      return {
+        isValid: false,
+        error: '유효한 경로 데이터가 없습니다. 최소 2개의 좌표가 필요합니다.',
+      };
+    }
+    const pathData = convertToApiFormat(mergedCoordinates);
+    const hasInvalidCoords = pathData.some(
+      (point) =>
+        !isFinite(point.lon) ||
+        !isFinite(point.lat) ||
+        Math.abs(point.lat) > 90 ||
+        Math.abs(point.lon) > 180,
+    );
+    if (hasInvalidCoords) {
+      return {
+        isValid: false,
+        error: '잘못된 좌표 데이터가 포함되어 있습니다.',
+      };
+    }
+    return {
+      isValid: true,
+      data: {
+        title,
+        path: pathData,
+      },
+    };
+  };
+
+  return { validateRoute };
+}

--- a/src/hooks/useRouteValidation.ts
+++ b/src/hooks/useRouteValidation.ts
@@ -1,12 +1,13 @@
 import { mergeMatchedRoutes, convertToApiFormat } from '@/utils/draw';
 import useDrawStore from '@/store/draw';
+import { RouteCoordinate } from '@/types/courses.types';
 
 export type ValidationResult = {
   isValid: boolean;
   error?: string;
   data?: {
     title: string;
-    path: any[];
+    path: RouteCoordinate[];
   };
 };
 

--- a/src/lib/coursesApi.ts
+++ b/src/lib/coursesApi.ts
@@ -1,0 +1,13 @@
+import api from './api';
+import type { CourseCreateRequest } from '@/types/courses.types';
+
+export async function createCourse(
+  data: CourseCreateRequest,
+  accessToken: string,
+): Promise<void> {
+  await api.post('/api/courses', data, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+}

--- a/src/lib/filesApi.ts
+++ b/src/lib/filesApi.ts
@@ -1,0 +1,52 @@
+import api from './api';
+import type {
+  PresignRequest,
+  PresignResponse,
+  S3UploadError,
+} from '@/types/files.types';
+
+export async function requestPresignedUrl(
+  data: PresignRequest,
+  accessToken: string,
+): Promise<PresignResponse> {
+  const response = await api.post<PresignResponse>('/files/presign', data, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  return response.data;
+}
+
+export async function uploadImageToS3(
+  presignedUrl: string,
+  imageUri: string,
+  fileSize: number,
+): Promise<void> {
+  const response = await fetch(imageUri);
+  const arrayBuffer = await response.arrayBuffer();
+
+  const uploadResponse = await fetch(presignedUrl, {
+    method: 'PUT',
+    body: arrayBuffer,
+    headers: {
+      'Content-Type': 'image/png',
+      'Content-Length': fileSize.toString(),
+    },
+  });
+
+  if (!uploadResponse.ok) {
+    const errorText = await uploadResponse.text();
+    const error = new Error(
+      `이미지 업로드에 실패했습니다. (${uploadResponse.status}): ${errorText}`,
+    ) as S3UploadError;
+    error.status = uploadResponse.status;
+    error.responseText = errorText;
+    throw error;
+  }
+}
+
+export function generatePublicImageUrl(bucket: string, key: string): string {
+  const region = 'ap-northeast-2';
+  return `https://${bucket}.s3.${region}.amazonaws.com/${key}`;
+}

--- a/src/navigation/RouteStackNavigator.tsx
+++ b/src/navigation/RouteStackNavigator.tsx
@@ -1,10 +1,12 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Route from '@/pages/Route';
 import Draw from '@/pages/Draw';
+import RouteSave from '@/pages/RouteSave';
 
 export type RouteStackParamList = {
   RouteMain: Record<string, never>;
   Draw: Record<string, never>;
+  RouteSave: Record<string, never>;
 };
 
 const Stack = createNativeStackNavigator<RouteStackParamList>();
@@ -14,6 +16,7 @@ export default function RouteStackNavigator() {
     <Stack.Navigator screenOptions={{ headerShown: false }}>
       <Stack.Screen name="RouteMain" component={Route} />
       <Stack.Screen name="Draw" component={Draw} />
+      <Stack.Screen name="RouteSave" component={RouteSave} />
     </Stack.Navigator>
   );
 }

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -69,7 +69,10 @@ export default function TabNavigator() {
             ),
             tabBarStyle: {
               ...baseTabBarStyle,
-              display: routeName === 'Draw' ? 'none' : 'flex',
+              display:
+                routeName === 'Draw' || routeName === 'RouteSave'
+                  ? 'none'
+                  : 'flex',
             },
           };
         }}

--- a/src/pages/Draw/_components/DrawMap.tsx
+++ b/src/pages/Draw/_components/DrawMap.tsx
@@ -1,4 +1,5 @@
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
+import styled from '@emotion/native';
 import Mapbox from '@rnmapbox/maps';
 import { theme } from '@/styles/theme';
 import type { DrawMapProps } from '@/types/draw.types';
@@ -17,7 +18,7 @@ export default function DrawMap({
     useDrawStore();
 
   return (
-    <View style={styles.container}>
+    <StyledContainer>
       <Map
         mapRef={mapRef}
         cameraRef={cameraRef}
@@ -94,12 +95,10 @@ export default function DrawMap({
       {!isCapturing && (
         <DrawUI onPanToCurrentUserLocation={onPanToCurrentUserLocation} />
       )}
-    </View>
+    </StyledContainer>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-});
+const StyledContainer = styled(View)`
+  flex: 1;
+`;

--- a/src/pages/Draw/_components/DrawUI.tsx
+++ b/src/pages/Draw/_components/DrawUI.tsx
@@ -1,4 +1,5 @@
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
+import styled from '@emotion/native';
 import { Edit3, Eraser, LocateFixed } from 'lucide-react-native';
 import { theme } from '@/styles/theme';
 import FloatingButton from '@/components/FloatingButton';
@@ -10,7 +11,7 @@ export default function DrawUI({ onPanToCurrentUserLocation }: DrawUIProps) {
 
   return (
     <>
-      <View style={styles.drawButtonContainer}>
+      <StyledDrawButtonContainer>
         <FloatingButton
           icon={Edit3}
           onPress={toggleDrawMode}
@@ -20,8 +21,8 @@ export default function DrawUI({ onPanToCurrentUserLocation }: DrawUIProps) {
           ]}
           iconColor={drawMode === 'draw' ? '#ffffff' : '#000000'}
         />
-      </View>
-      <View style={styles.eraseButtonContainer}>
+      </StyledDrawButtonContainer>
+      <StyledEraseButtonContainer>
         <FloatingButton
           icon={Eraser}
           onPress={toggleEraseMode}
@@ -31,35 +32,38 @@ export default function DrawUI({ onPanToCurrentUserLocation }: DrawUIProps) {
           ]}
           iconColor={drawMode === 'erase' ? '#ffffff' : '#000000'}
         />
-      </View>
-      <View style={styles.locateButtonContainer}>
+      </StyledEraseButtonContainer>
+      <StyledLocateButtonContainer>
         <FloatingButton
           icon={LocateFixed}
           onPress={onPanToCurrentUserLocation}
           style={styles.defaultButton}
           iconColor="#000000"
         />
-      </View>
+      </StyledLocateButtonContainer>
     </>
   );
 }
 
-const styles = StyleSheet.create({
-  drawButtonContainer: {
-    position: 'absolute',
-    right: 0,
-    bottom: 10,
-  },
-  eraseButtonContainer: {
-    position: 'absolute',
-    right: 0,
-    bottom: -60,
-  },
-  locateButtonContainer: {
-    position: 'absolute',
-    right: 0,
-    top: 200,
-  },
+const StyledDrawButtonContainer = styled(View)`
+  position: absolute;
+  right: 0;
+  bottom: 10px;
+`;
+
+const StyledEraseButtonContainer = styled(View)`
+  position: absolute;
+  right: 0;
+  bottom: -60px;
+`;
+
+const StyledLocateButtonContainer = styled(View)`
+  position: absolute;
+  right: 0;
+  top: 200px;
+`;
+
+const styles = {
   defaultButton: {
     backgroundColor: '#ffffff',
   },
@@ -68,4 +72,4 @@ const styles = StyleSheet.create({
     elevation: 12,
     shadowOpacity: 0.5,
   },
-});
+};

--- a/src/pages/Draw/_components/Toasts.tsx
+++ b/src/pages/Draw/_components/Toasts.tsx
@@ -1,0 +1,41 @@
+import Toast from 'react-native-toast-message';
+
+export const showMapCaptureSuccess = () => {
+  Toast.show({
+    type: 'success',
+    text1: '맵 캡처 성공',
+    text2: '이미지가 캡처되었습니다.',
+  });
+};
+
+export const showImageUploadSuccess = () => {
+  Toast.show({
+    type: 'success',
+    text1: '이미지 업로드 성공',
+    text2: '경로 이미지가 업로드되었습니다.',
+  });
+};
+
+export const showImageProcessingError = (errorMessage: string) => {
+  Toast.show({
+    type: 'error',
+    text1: '이미지 처리 실패',
+    text2: errorMessage,
+  });
+};
+
+export const showCourseSaveSuccess = () => {
+  Toast.show({
+    type: 'success',
+    text1: '경로 저장 성공',
+    text2: '경로가 성공적으로 저장되었습니다.',
+  });
+};
+
+export const showCourseSaveError = (errorMessage: string) => {
+  Toast.show({
+    type: 'error',
+    text1: '경로 저장 실패',
+    text2: errorMessage,
+  });
+};

--- a/src/pages/Draw/index.tsx
+++ b/src/pages/Draw/index.tsx
@@ -14,7 +14,6 @@ import { useLocationManager } from '@/hooks/useLocationManager';
 import { useRouteValidation } from '@/hooks/useRouteValidation';
 import { useMapCapture } from '@/hooks/useMapCapture';
 import { createCourse } from '@/lib/coursesApi';
-import type { AxiosErrorResponse } from '@/types/api.types';
 import Header from '@/components/Header';
 import DrawMap from './_components/DrawMap';
 import type { RouteStackParamList } from '@/navigation/RouteStackNavigator';
@@ -97,20 +96,10 @@ export default function Draw() {
       );
 
       showCourseSaveSuccess();
-    } catch (error: any) {
+      clearAll();
+      navigation.goBack();
+    } catch (error: unknown) {
       let errorMessage = '경로 저장에 실패했습니다.';
-      const response = error.response as AxiosErrorResponse | undefined;
-      if (response?.data?.message) {
-        errorMessage = response.data.message;
-      } else if (response?.data?.error) {
-        errorMessage =
-          typeof response.data.error === 'string'
-            ? response.data.error
-            : JSON.stringify(response.data.error);
-      } else if (error.message) {
-        errorMessage = error.message;
-      }
-
       showCourseSaveError(errorMessage);
     }
   };

--- a/src/pages/Draw/index.tsx
+++ b/src/pages/Draw/index.tsx
@@ -49,7 +49,7 @@ export default function Draw() {
     handleUserLocationUpdate,
   } = useLocationManager();
   const { composedGesture } = useMapGestures(mapRef);
-  const { processImage } = useMapCapture(mapRef);
+  const { processImage } = useMapCapture(mapRef, cameraRef);
   const { validateRoute } = useRouteValidation();
 
   useFocusEffect(
@@ -70,7 +70,7 @@ export default function Draw() {
         return;
       }
 
-      const imageResult = await processImage(accessToken || '');
+      const imageResult = await processImage();
       if (imageResult.captureError) {
         showImageProcessingError(imageResult.captureError);
         return;

--- a/src/pages/Draw/index.tsx
+++ b/src/pages/Draw/index.tsx
@@ -1,5 +1,6 @@
 import { useRef, useCallback } from 'react';
-import { View, StyleSheet, ActivityIndicator, Alert } from 'react-native';
+import { View, ActivityIndicator, Alert } from 'react-native';
+import styled from '@emotion/native';
 import Mapbox from '@rnmapbox/maps';
 import {
   GestureDetector,
@@ -25,9 +26,9 @@ import {
 } from './_components/Toasts';
 
 const LoadingIndicator = () => (
-  <View style={styles.loadingOverlay}>
+  <StyledLoadingOverlay>
     <ActivityIndicator size="large" color={theme.colors.primary[500]} />
-  </View>
+  </StyledLoadingOverlay>
 );
 
 export default function Draw() {
@@ -99,7 +100,7 @@ export default function Draw() {
   }
 
   return (
-    <GestureHandlerRootView style={styles.screen}>
+    <StyledGestureHandlerRootView>
       <Header
         title="경로 그리기"
         leftIcon={ArrowLeft}
@@ -107,9 +108,9 @@ export default function Draw() {
         onLeftPress={handleBackPress}
         onRightPress={handleSavePress}
       />
-      <View style={styles.container}>
+      <StyledContainer>
         <GestureDetector gesture={composedGesture}>
-          <View style={styles.container} collapsable={false}>
+          <StyledContainer collapsable={false}>
             <DrawMap
               mapRef={mapRef}
               cameraRef={cameraRef}
@@ -119,27 +120,31 @@ export default function Draw() {
               }
               onUserLocationUpdate={handleUserLocationUpdate}
             />
-          </View>
+          </StyledContainer>
         </GestureDetector>
         {isLoading && <LoadingIndicator />}
-      </View>
-    </GestureHandlerRootView>
+      </StyledContainer>
+    </StyledGestureHandlerRootView>
   );
 }
 
-const styles = StyleSheet.create({
-  screen: {
-    flex: 1,
-    backgroundColor: '#ffffff',
-  },
-  container: {
-    flex: 1,
-  },
-  loadingOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0, 0, 0, 0.4)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    zIndex: 10,
-  },
-});
+const StyledGestureHandlerRootView = styled(GestureHandlerRootView)`
+  flex: 1;
+  background-color: #ffffff;
+`;
+
+const StyledContainer = styled(View)`
+  flex: 1;
+`;
+
+const StyledLoadingOverlay = styled(View)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
+`;

--- a/src/pages/RouteSave/index.tsx
+++ b/src/pages/RouteSave/index.tsx
@@ -9,6 +9,7 @@ import {
   KeyboardAvoidingView,
   Platform,
   ScrollView,
+  TouchableOpacity,
 } from 'react-native';
 import styled from '@emotion/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -117,7 +118,7 @@ export default function RouteSave() {
           },
         },
       ]);
-    } catch (error: any) {
+    } catch (error: unknown) {
       Alert.alert('오류', '경로 저장에 실패했습니다.');
     } finally {
       setIsSaving(false);
@@ -197,7 +198,7 @@ export default function RouteSave() {
       >
         <StyledSaveButton
           disabled={!title.trim() || isSaving}
-          onTouchEnd={handleSave}
+          onPress={handleSave}
         >
           {isSaving ? (
             <ActivityIndicator color="#ffffff" />
@@ -298,7 +299,7 @@ const StyledButtonContainer = styled(View)`
   padding-top: 16px;
 `;
 
-const StyledSaveButton = styled(View)<{ disabled?: boolean }>`
+const StyledSaveButton = styled(TouchableOpacity)<{ disabled?: boolean }>`
   background-color: ${(props) =>
     props.disabled ? theme.colors.gray[300] : theme.colors.primary[500]};
   border-radius: 8px;

--- a/src/pages/RouteSave/index.tsx
+++ b/src/pages/RouteSave/index.tsx
@@ -1,0 +1,310 @@
+import { useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  Image,
+  Alert,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { ArrowLeft } from 'lucide-react-native';
+import { theme } from '@/styles/theme';
+import Header from '@/components/Header';
+import { reverseGeocode } from '@/utils/geocoding';
+import { createCourse } from '@/lib/coursesApi';
+import { useImageUpload } from '@/hooks/useImageUpload';
+import useAuthStore from '@/store/auth';
+import useDrawStore from '@/store/draw';
+import { useRouteSaveStore } from '@/store/routeSave';
+import type { RouteStackParamList } from '@/navigation/RouteStackNavigator';
+
+type RouteSaveScreenNavigationProp = NativeStackNavigationProp<
+  RouteStackParamList,
+  'RouteSave'
+>;
+
+export default function RouteSave() {
+  const navigation = useNavigation<RouteSaveScreenNavigationProp>();
+  const routeData = useRouteSaveStore((s) => s.routeData);
+
+  const [title, setTitle] = useState('');
+  const [address, setAddress] = useState('위치 정보를 가져오는 중...');
+  const [isSaving, setIsSaving] = useState(false);
+  const [imageLoading, setImageLoading] = useState(!!routeData?.imageURL);
+  const [imageError, setImageError] = useState(false);
+
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const clearAll = useDrawStore((s) => s.clearAll);
+  const clearRouteData = useRouteSaveStore((s) => s.clearRouteData);
+  const { uploadImage } = useImageUpload();
+
+  useEffect(() => {
+    if (!routeData) {
+      navigation.goBack();
+      return;
+    }
+
+    const fetchAddress = async () => {
+      try {
+        const result = await reverseGeocode(routeData.startLocation);
+        setAddress(result.address);
+      } catch (error) {
+        setAddress('위치 정보를 가져올 수 없습니다');
+      }
+    };
+
+    fetchAddress();
+  }, [routeData, navigation]);
+
+  const handleBackPress = () => {
+    clearRouteData();
+    navigation.goBack();
+  };
+
+  const handleSave = async () => {
+    if (!title.trim()) {
+      Alert.alert('오류', '경로 이름을 입력해주세요.');
+      return;
+    }
+
+    if (!accessToken) {
+      Alert.alert('오류', '로그인이 필요합니다.');
+      return;
+    }
+
+    if (!routeData) {
+      Alert.alert('오류', '경로 데이터가 없습니다.');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      // 저장 시에만 이미지를 S3에 업로드
+      let finalImageURL = '';
+      if (routeData.imageURL && routeData.imageURL.startsWith('file://')) {
+        finalImageURL = await uploadImage(routeData.imageURL, accessToken);
+      } else {
+        finalImageURL = routeData.imageURL;
+      }
+
+      const courseData = {
+        title: title.trim(),
+        imageURL: finalImageURL,
+        path: routeData.path,
+      };
+
+      await createCourse(courseData, accessToken);
+
+      Alert.alert('성공', '경로가 저장되었습니다.', [
+        {
+          text: '확인',
+          onPress: () => {
+            clearAll();
+            clearRouteData();
+            navigation.reset({
+              index: 0,
+              routes: [{ name: 'RouteMain' }],
+            });
+          },
+        },
+      ]);
+    } catch (error: any) {
+      Alert.alert('오류', '경로 저장에 실패했습니다.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <Header
+        title="경로 저장"
+        leftIcon={ArrowLeft}
+        onLeftPress={handleBackPress}
+      />
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        {/* 시작 위치 */}
+        <View style={styles.locationSection}>
+          <Text style={styles.sectionTitle}>시작 위치</Text>
+          <Text style={styles.addressText}>{address}</Text>
+        </View>
+
+        {/* 경로 이름 입력 */}
+        <View style={styles.inputSection}>
+          <Text style={styles.sectionTitle}>경로 이름</Text>
+          <TextInput
+            style={styles.textInput}
+            placeholder="경로 이름을 입력하세요"
+            value={title}
+            onChangeText={setTitle}
+            maxLength={50}
+            autoFocus
+          />
+        </View>
+
+        {/* 경로 이미지 */}
+        <View style={styles.imageSection}>
+          <Text style={styles.sectionTitle}>경로 미리보기</Text>
+          <View style={styles.imageContainer}>
+            {routeData?.imageURL &&
+            routeData.imageURL.trim() !== '' &&
+            !imageError ? (
+              <>
+                <Image
+                  source={{ uri: routeData.imageURL }}
+                  style={styles.routeImage}
+                  resizeMode="cover"
+                  onLoadStart={() => {
+                    setImageLoading(true);
+                    setImageError(false);
+                  }}
+                  onLoadEnd={() => setImageLoading(false)}
+                  onError={() => {
+                    setImageLoading(false);
+                    setImageError(true);
+                  }}
+                />
+                {imageLoading && (
+                  <View style={styles.imageLoadingOverlay}>
+                    <ActivityIndicator color={theme.colors.primary[500]} />
+                  </View>
+                )}
+              </>
+            ) : (
+              <View style={styles.imagePlaceholder}>
+                <Text style={styles.placeholderText}>
+                  {imageError
+                    ? '이미지 로딩 실패\n(권한 또는 네트워크 문제)'
+                    : !routeData?.imageURL || routeData.imageURL.trim() === ''
+                      ? '이미지가 없습니다'
+                      : '이미지를 불러올 수 없습니다'}
+                </Text>
+              </View>
+            )}
+          </View>
+        </View>
+      </ScrollView>
+
+      {/* 저장 버튼 */}
+      <View style={styles.buttonContainer}>
+        <View
+          style={[
+            styles.saveButton,
+            (!title.trim() || isSaving) && styles.saveButtonDisabled,
+          ]}
+          onTouchEnd={handleSave}
+        >
+          {isSaving ? (
+            <ActivityIndicator color="#ffffff" />
+          ) : (
+            <Text style={styles.saveButtonText}>저장하기</Text>
+          )}
+        </View>
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+  locationSection: {
+    marginTop: 24,
+    marginBottom: 32,
+  },
+  inputSection: {
+    marginBottom: 32,
+  },
+  imageSection: {
+    marginBottom: 32,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: theme.colors.gray[900],
+    marginBottom: 12,
+  },
+  addressText: {
+    fontSize: 14,
+    color: theme.colors.gray[600],
+    lineHeight: 20,
+  },
+  textInput: {
+    borderWidth: 1,
+    borderColor: theme.colors.gray[300],
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    fontSize: 16,
+    color: theme.colors.gray[900],
+    backgroundColor: '#ffffff',
+  },
+  imageContainer: {
+    alignItems: 'center',
+  },
+  routeImage: {
+    width: '100%',
+    height: 200,
+    borderRadius: 8,
+  },
+  imagePlaceholder: {
+    width: '100%',
+    height: 200,
+    borderRadius: 8,
+    backgroundColor: theme.colors.gray[100],
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  placeholderText: {
+    fontSize: 14,
+    color: theme.colors.gray[500],
+  },
+  imageLoadingOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(255, 255, 255, 0.8)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 8,
+  },
+  buttonContainer: {
+    paddingHorizontal: 20,
+    paddingBottom: 34,
+    paddingTop: 16,
+  },
+  saveButton: {
+    backgroundColor: theme.colors.primary[500],
+    borderRadius: 8,
+    paddingVertical: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 56,
+  },
+  saveButtonDisabled: {
+    backgroundColor: theme.colors.gray[300],
+  },
+  saveButtonText: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/src/pages/RouteSave/index.tsx
+++ b/src/pages/RouteSave/index.tsx
@@ -263,13 +263,13 @@ const StyledImageContainer = styled(View)`
 
 const StyledRouteImage = styled(Image)`
   width: 100%;
-  height: 200px;
+  aspect-ratio: 1;
   border-radius: 8px;
 `;
 
 const StyledImagePlaceholder = styled(View)`
   width: 100%;
-  height: 200px;
+  aspect-ratio: 1;
   border-radius: 8px;
   background-color: ${theme.colors.gray[100]};
   justify-content: center;

--- a/src/pages/Run/_components/RunMap.tsx
+++ b/src/pages/Run/_components/RunMap.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
+import styled from '@emotion/native';
 import Mapbox from '@rnmapbox/maps';
 import type { Feature, LineString } from 'geojson';
 import type * as Location from 'expo-location';
@@ -16,7 +17,7 @@ export default function RunMap({ location, routeGeoJSON }: RunMapProps) {
   const cameraRef = useRef<Mapbox.Camera>(null);
 
   return (
-    <View style={styles.container}>
+    <StyledContainer>
       <Map
         mapRef={mapRef}
         cameraRef={cameraRef}
@@ -36,13 +37,12 @@ export default function RunMap({ location, routeGeoJSON }: RunMapProps) {
           </Mapbox.ShapeSource>
         )}
       </Map>
-    </View>
+    </StyledContainer>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    width: '100%',
-  },
-});
+// Styled Components
+const StyledContainer = styled(View)`
+  flex: 1;
+  width: 100%;
+`;

--- a/src/pages/Run/index.tsx
+++ b/src/pages/Run/index.tsx
@@ -1,4 +1,5 @@
-import { View, StyleSheet, Text } from 'react-native';
+import { View, Text } from 'react-native';
+import styled from '@emotion/native';
 import { theme } from '@/styles/theme';
 import type { Feature, LineString } from 'geojson';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -21,8 +22,8 @@ export default function Run() {
   };
 
   return (
-    <View style={styles.page}>
-      <View style={styles.container}>
+    <StyledPage>
+      <StyledContainer>
         {errorMsg ? (
           <Text>{errorMsg}</Text>
         ) : location ? (
@@ -30,26 +31,21 @@ export default function Run() {
         ) : (
           <Text>Getting location...</Text>
         )}
-      </View>
-    </View>
+      </StyledContainer>
+    </StyledPage>
   );
 }
 
-const styles = StyleSheet.create({
-  page: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: theme.colors.gray[100],
-  },
-  container: {
-    height: '100%',
-    width: '100%',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  map: {
-    flex: 1,
-    width: '100%',
-  },
-});
+const StyledPage = styled(View)`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  background-color: ${theme.colors.gray[100]};
+`;
+
+const StyledContainer = styled(View)`
+  height: 100%;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/store/draw.ts
+++ b/src/store/draw.ts
@@ -65,6 +65,7 @@ const useDrawStore = create<DrawState>((set) => ({
       matchedRoutes: [],
       completedDrawings: [],
       drawnCoordinates: [],
+      drawMode: 'none',
     }),
 }));
 

--- a/src/store/routeSave.ts
+++ b/src/store/routeSave.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand';
+import { RouteCoordinate } from '@/types/courses.types';
+
+export interface RouteSaveData {
+  startLocation: [number, number];
+  imageURL: string;
+  path: RouteCoordinate[];
+}
+
+interface RouteSaveState {
+  routeData: RouteSaveData | null;
+  setRouteData: (data: RouteSaveData) => void;
+  clearRouteData: () => void;
+}
+
+export const useRouteSaveStore = create<RouteSaveState>((set) => ({
+  routeData: null,
+  setRouteData: (data) => set({ routeData: data }),
+  clearRouteData: () => set({ routeData: null }),
+}));

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -1,0 +1,11 @@
+export interface ApiErrorResponse {
+  message?: string;
+  error?: string | object;
+  statusCode?: number;
+}
+
+export interface AxiosErrorResponse {
+  data?: ApiErrorResponse;
+  status?: number;
+  statusText?: string;
+}

--- a/src/types/courses.types.ts
+++ b/src/types/courses.types.ts
@@ -1,3 +1,5 @@
+import { ImageProcessResult } from './image.types';
+
 export interface RouteCoordinate {
   lon: number;
   lat: number;
@@ -19,5 +21,5 @@ export type CourseSaveResult = {
   success: boolean;
   data?: CourseSaveData;
   error?: string;
-  imageProcessResult?: any;
+  imageProcessResult?: ImageProcessResult;
 };

--- a/src/types/courses.types.ts
+++ b/src/types/courses.types.ts
@@ -1,0 +1,10 @@
+export interface RouteCoordinate {
+  lon: number;
+  lat: number;
+}
+
+export interface CourseCreateRequest {
+  title: string;
+  imageURL: string;
+  path: RouteCoordinate[];
+}

--- a/src/types/courses.types.ts
+++ b/src/types/courses.types.ts
@@ -8,3 +8,16 @@ export interface CourseCreateRequest {
   imageURL: string;
   path: RouteCoordinate[];
 }
+
+export type CourseSaveData = {
+  title: string;
+  imageURL: string;
+  path: RouteCoordinate[];
+};
+
+export type CourseSaveResult = {
+  success: boolean;
+  data?: CourseSaveData;
+  error?: string;
+  imageProcessResult?: any;
+};

--- a/src/types/files.types.ts
+++ b/src/types/files.types.ts
@@ -1,0 +1,18 @@
+export type FileUploadType = 'avatar' | 'verify';
+
+export interface PresignRequest {
+  type: FileUploadType;
+  contentType: string;
+  size: number;
+}
+
+export interface PresignResponse {
+  bucket: string;
+  key: string;
+  url: string;
+}
+
+export interface S3UploadError extends Error {
+  status?: number;
+  responseText?: string;
+}

--- a/src/types/image.types.ts
+++ b/src/types/image.types.ts
@@ -1,0 +1,9 @@
+export type ImageProcessResult = {
+  success: boolean;
+  imageURL?: string;
+  error?: string;
+  captureSuccess?: boolean;
+  uploadSuccess?: boolean;
+  captureError?: string;
+  uploadError?: string;
+};

--- a/src/utils/draw.ts
+++ b/src/utils/draw.ts
@@ -1,4 +1,5 @@
 import type { Position, Feature, LineString } from 'geojson';
+import type { RouteCoordinate } from '@/types/courses.types';
 
 export function findClosestRouteIndex(
   tappedCoord: Position,
@@ -24,4 +25,34 @@ export function findClosestRouteIndex(
   });
 
   return { closestRouteIndex, minDistance };
+}
+
+export function mergeMatchedRoutes(
+  matchedRoutes: Feature<LineString>[],
+): Position[] {
+  const mergedCoordinates: Position[] = [];
+  matchedRoutes.forEach((route) => {
+    if (route.geometry.type === 'LineString') {
+      const coordinates = route.geometry.coordinates;
+
+      if (mergedCoordinates.length > 0) {
+        const lastCoord = mergedCoordinates[mergedCoordinates.length - 1];
+        const firstCoord = coordinates[0];
+
+        if (lastCoord[0] === firstCoord[0] && lastCoord[1] === firstCoord[1]) {
+          mergedCoordinates.push(...coordinates.slice(1));
+        } else {
+          mergedCoordinates.push(...coordinates);
+        }
+      } else {
+        mergedCoordinates.push(...coordinates);
+      }
+    }
+  });
+
+  return mergedCoordinates;
+}
+
+export function convertToApiFormat(coordinates: Position[]): RouteCoordinate[] {
+  return coordinates.map(([lon, lat]) => ({ lon, lat }));
 }

--- a/src/utils/geocoding.ts
+++ b/src/utils/geocoding.ts
@@ -1,0 +1,43 @@
+import type { Position } from 'geojson';
+
+export interface GeocodingResult {
+  address: string;
+  placeName: string;
+}
+
+export async function reverseGeocode(
+  coordinates: Position,
+): Promise<GeocodingResult> {
+  const [longitude, latitude] = coordinates;
+  const accessToken = process.env.EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN;
+
+  if (!accessToken) {
+    throw new Error('Mapbox 액세스 토큰이 설정되지 않았습니다.');
+  }
+
+  const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${longitude},${latitude}.json?access_token=${accessToken}&types=address,poi`;
+
+  try {
+    const response = await fetch(url);
+    const data = await response.json();
+
+    if (data.features && data.features.length > 0) {
+      const feature = data.features[0];
+      return {
+        address: feature.place_name || '알 수 없는 위치',
+        placeName: feature.text || '알 수 없는 위치',
+      };
+    }
+
+    return {
+      address: '알 수 없는 위치',
+      placeName: '알 수 없는 위치',
+    };
+  } catch (error) {
+    console.error('지오코딩 오류:', error);
+    return {
+      address: '알 수 없는 위치',
+      placeName: '알 수 없는 위치',
+    };
+  }
+}


### PR DESCRIPTION
## 작업 내용

- `/api/courses`, `/api/files/presign` api 연동
- 생성한 경로, 이미지 저장하는 기능 구현
- (기존) save 아이콘 탭 시 즉시 이미지 업로드 + 경로 생성 api 요청
- (개선) save 아이콘 탭 시 routesave 스크린으로 이동, title 입력받은 후 저장하기 버튼으로 api 요청
- routesave 스크린에서 시작 위치 표시를 위한 geocoing 유틸 추가 
- draw/index.tsx 책임 분리-> 흐름 아래 사진 참고
- `useMapCapture` 훅 개선
  - 기존 캡처 기능은 사용자 현재 위치를 기준으로 캡처
  - 사용자 현재 위치와 상관없이 그린 경로가 항상 캡처 이미지 중앙에 위치하도록 코드 개선


## 참고 사항

-
