### PR TITLE
Feature: 경로 생성 api path 형식 업데이트

### DIFF
--- a/src/pages/RouteSave/index.tsx
+++ b/src/pages/RouteSave/index.tsx
@@ -99,7 +99,7 @@ export default function RouteSave() {
 
       const courseData = {
         title: title.trim(),
-        imageURL: finalImageURL,
+        imageUrl: finalImageURL,
         path: routeData.path,
       };
 

--- a/src/services/courses.service.ts
+++ b/src/services/courses.service.ts
@@ -1,17 +1,12 @@
+import { convertPathToApiFormat } from '@/utils/courseFormatter';
 import api from '../lib/api';
 import type {
+  CourseClientData,
   CourseCreateRequest,
-  RouteCoordinate,
 } from '@/types/courses.types';
 
-// courses api 요청 형식 변경
-// RouteCoordinate[]를 number[][]로 변환하는 헬퍼 함수
-function convertPathToApiFormat(path: RouteCoordinate[]): number[][] {
-  return path.map((coord) => [coord.lon, coord.lat]);
-}
-
 export async function createCourse(
-  data: Omit<CourseCreateRequest, 'path'> & { path: RouteCoordinate[] },
+  data: CourseClientData,
   accessToken: string,
 ): Promise<void> {
   const apiData: CourseCreateRequest = {

--- a/src/services/courses.service.ts
+++ b/src/services/courses.service.ts
@@ -1,11 +1,25 @@
 import api from '../lib/api';
-import type { CourseCreateRequest } from '@/types/courses.types';
+import type {
+  CourseCreateRequest,
+  RouteCoordinate,
+} from '@/types/courses.types';
+
+// courses api 요청 형식 변경
+// RouteCoordinate[]를 number[][]로 변환하는 헬퍼 함수
+function convertPathToApiFormat(path: RouteCoordinate[]): number[][] {
+  return path.map((coord) => [coord.lon, coord.lat]);
+}
 
 export async function createCourse(
-  data: CourseCreateRequest,
+  data: Omit<CourseCreateRequest, 'path'> & { path: RouteCoordinate[] },
   accessToken: string,
 ): Promise<void> {
-  await api.post('/api/courses', data, {
+  const apiData: CourseCreateRequest = {
+    ...data,
+    path: convertPathToApiFormat(data.path),
+  };
+
+  await api.post('/api/courses', apiData, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },

--- a/src/types/courses.types.ts
+++ b/src/types/courses.types.ts
@@ -7,8 +7,8 @@ export interface RouteCoordinate {
 
 export interface CourseCreateRequest {
   title: string;
-  imageURL: string;
-  path: RouteCoordinate[];
+  imageUrl: string;
+  path: number[][];
 }
 
 export type CourseSaveData = {

--- a/src/types/courses.types.ts
+++ b/src/types/courses.types.ts
@@ -8,7 +8,13 @@ export interface RouteCoordinate {
 export interface CourseCreateRequest {
   title: string;
   imageUrl: string;
-  path: number[][];
+  path: [number, number][];
+}
+
+export interface CourseClientData {
+  title: string;
+  imageUrl: string;
+  path: RouteCoordinate[];
 }
 
 export type CourseSaveData = {

--- a/src/utils/courseFormatter.ts
+++ b/src/utils/courseFormatter.ts
@@ -1,0 +1,7 @@
+import { RouteCoordinate } from '@/types/courses.types';
+
+export function convertPathToApiFormat(
+  path: RouteCoordinate[],
+): [number, number][] {
+  return path.map((coord) => [coord.lon, coord.lat] as [number, number]);
+}


### PR DESCRIPTION
## 작업 내용

- 백엔드에서 path 필드 형식 변경함에 따라 기존 RouteCoordinate[] 형식으로 사용하던 path 필드를 number[][] 형식으로 변경
- 변경 사항이 기존 코드들에 영향 가지 않도록 RouteCoordinate[]는 유지, /course api 호출 시에만 number[][] 형식으로 변환하여 요청 보내도록 헬퍼 함수 구현

```
function convertPathToApiFormat(path: RouteCoordinate[]): number[][] {
  return path.map((coord) => [coord.lon, coord.lat]);
}
```

## 참고 사항

-
