### PR TITLE
Fix: run 스크린 직접 접속 시에도 토폴로지 표시되는 오류 수정

### DIFF
--- a/src/hooks/useRunModals.ts
+++ b/src/hooks/useRunModals.ts
@@ -57,6 +57,8 @@ export function useRunModals({
   const handleConfirmBack = useCallback(() => {
     resetLocationTracking();
     resetRunState();
+    // courseId 파라미터 초기화
+    navigation.setParams({ courseId: undefined });
     navigation.goBack();
   }, [resetLocationTracking, resetRunState, navigation]);
 
@@ -73,6 +75,8 @@ export function useRunModals({
     if (!startTime || routeCoordinates.length === 0) {
       resetLocationTracking();
       resetRunState();
+      // courseId 파라미터 초기화
+      navigation.setParams({ courseId: undefined });
       navigation.goBack();
       return;
     }
@@ -137,6 +141,8 @@ export function useRunModals({
 
       resetLocationTracking();
       resetRunState();
+      // courseId 파라미터 초기화
+      navigation.setParams({ courseId: undefined });
       navigation.goBack();
     } catch (error: unknown) {
       let errorMessage = '런닝 기록 저장에 실패했습니다.';


### PR DESCRIPTION
## 작업 내용

- route에서 경로를 선택했다가 이탈한 후, run 스크린 직접 접속하면 이전에 선택했던 경로 토폴로지가 그대로 표시되는 오류
- 원인: courseId params가 초기화되지 않고 직접 접속시에도 넘겨짐
- 해결: 뒤로가기나 종료 시, courseId 초기화하도록 설정


## 참고 사항

-
